### PR TITLE
Linguist fixes based on raiph's PR

### DIFF
--- a/dev/raku.tmLanguage.raku
+++ b/dev/raku.tmLanguage.raku
@@ -1494,7 +1494,7 @@
           (
               (?:[\pL\pM_])           # Must start with Alpha or underscore
               (?:
-                 [\\p{Digit}\pL\pM_]  # have alphanum/underscore, or a ' or -
+                 [\p{Digit}\pL\pM_]  # have alphanum/underscore, or a ' or -
               |                           # followed by an Alpha or underscore
                  [\-'] [\pL\pM_]
               )*

--- a/dev/raku.tmLanguage.raku
+++ b/dev/raku.tmLanguage.raku
@@ -441,7 +441,7 @@
         '4' => {
           'patterns' => [
             {
-              'match' => '(?x) ( [\\p{Digit}\\p{Alpha}\'\\-_]+ ) \\b (:)? (\\w+ \\b )? (\\S+  )?',
+              'match' => Q/(?x) ( [\p{Digit}\pL\pM'\-_]+ ) \b (:)? (\w+ \b )? (\S+  )?/,
               'captures' => {
                 '1' => {
                   'name' => 'entity.name.function.raku'
@@ -486,7 +486,7 @@
           'name' => 'entity.name.function.regexp.named.TOP.raku'
         },
         {
-          'match' => '[\\p{Digit}\\p{Alpha}\'\\-_]+',
+          'match' => Q/[\p{Digit}\pL\pM'\-_]+/,
           'name' => 'entity.name.function.regexp.named.raku'
         },
         {
@@ -1487,16 +1487,16 @@
           'include' => '#regexp-variables'
         },
         {
-          'match' => q:to/REGEX/.chomp,
+          'match' => Q:to/REGEX/.chomp,
           (?x)
-          (\\$|@|%|&)
-          (\\.|\\*|:|!|\\^|~|=|\\?)?
+          (\$|@|%|&)
+          (\.|\*|:|!|\^|~|=|\?)?
           (
-              (?:[\\p{Alpha}_])           # Must start with Alpha or underscore
+              (?:[\pL\pM_])           # Must start with Alpha or underscore
               (?:
-                 [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -
+                 [\\p{Digit}\pL\pM_]  # have alphanum/underscore, or a ' or -
               |                           # followed by an Alpha or underscore
-                 [\\-'] [\\p{Alpha}_]
+                 [\-'] [\pL\pM_]
               )*
           )
           REGEX
@@ -1540,34 +1540,34 @@
     'interpolation' => {
       'patterns' => [
         {
-          'match' => q:to/REGEX/.chomp,
+          'match' => Q:to/REGEX/.chomp,
           (?x)
-          (?<!\\\\)
-          (\\$|@|%|&)
-          (?!\\$)
-          (\\.|\\*|:|!|\\^|~|=|\\?)?  # Twigils
-          ([\\p{Alpha}_])             # Must start with Alpha or underscore
+          (?<!\\)
+          (\$|@|%|&)
+          (?!\$)
+          (\.|\*|:|!|\^|~|=|\?)?  # Twigils
+          ([\pL\pM_])             # Must start with Alpha or underscore
           (
-             [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -
+             [\p{Digit}\pL\pM_]  # have alphanum/underscore, or a ' or -
           |                           # followed by an Alpha or underscore
-             [\\-'] [\\p{Alpha}_]
+             [\-'] [\pL\pM_]
           )*
-          ( \\[ .* \\] )?             # postcircumfix [ ]
+          ( \[ .* \] )?             # postcircumfix [ ]
           ## methods
           (?:
             (?:
-              ( \\. )
+              ( \. )
               (
-                 [\\p{Alpha}]
+                 [\pL\pM]
                   (?:
-                    [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -
+                    [\p{Digit}\pL\pM_]  # have alphanum/underscore, or a ' or -
                   |                          # followed by an Alpha or underscore
-                    [\\-'] [\\p{Alpha}_]
+                    [\-'] [\pL\pM_]
                   )*
           
               )
             )?
-            ( \\( .*?  \\) )
+            ( \( .*?  \) )
           )?
           REGEX
           'captures' => {
@@ -1621,13 +1621,13 @@
               'name' => 'support.function.raku'
             },
             '8' => {
-              'begin' => '(',
+              'begin' => Q<\(>,
               'beginCaptures' => {
                 '0' => {
                   'name' => 'keyword.operator.paren.open.raku'
                 }
               },
-              'end' => ')',
+              'end' => Q<\)>,
               'endCaptures' => {
                 '0' => {
                   'name' => 'keyword.operator.paren.close.raku'

--- a/grammars/raku.tmLanguage.json
+++ b/grammars/raku.tmLanguage.json
@@ -1235,7 +1235,7 @@
                   ]
                 }
               },
-              "match": "(?x) ( [\\p{Digit}\\p{Alpha}'\\-_]+ ) \\b (:)? (\\w+ \\b )? (\\S+  )?"
+              "match": "(?x) ( [\\p{Digit}\\pL\\pM'\\-_]+ ) \\b (:)? (\\w+ \\b )? (\\S+  )?"
             }
           ]
         }
@@ -1262,7 +1262,7 @@
           "name": "entity.name.function.regexp.named.TOP.raku"
         },
         {
-          "match": "[\\p{Digit}\\p{Alpha}'\\-_]+",
+          "match": "[\\p{Digit}\\pL\\pM'\\-_]+",
           "name": "entity.name.function.regexp.named.raku"
         },
         {
@@ -2167,13 +2167,13 @@
               "name": "support.function.raku"
             },
             "8": {
-              "begin": "(",
+              "begin": "\\(",
               "beginCaptures": {
                 "0": {
                   "name": "keyword.operator.paren.open.raku"
                 }
               },
-              "end": ")",
+              "end": "\\)",
               "endCaptures": {
                 "0": {
                   "name": "keyword.operator.paren.close.raku"
@@ -2186,7 +2186,7 @@
               ]
             }
           },
-          "match": "(?x)\n(?<!\\\\)\n(\\$|@|%|&)\n(?!\\$)\n(\\.|\\*|:|!|\\^|~|=|\\?)?  # Twigils\n([\\p{Alpha}_])             # Must start with Alpha or underscore\n(\n   [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -\n|                           # followed by an Alpha or underscore\n   [\\-'] [\\p{Alpha}_]\n)*\n( \\[ .* \\] )?             # postcircumfix [ ]\n## methods\n(?:\n  (?:\n    ( \\. )\n    (\n       [\\p{Alpha}]\n        (?:\n          [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -\n        |                          # followed by an Alpha or underscore\n          [\\-'] [\\p{Alpha}_]\n        )*\n\n    )\n  )?\n  ( \\( .*?  \\) )\n)?",
+          "match": "(?x)\n(?<!\\\\)\n(\\$|@|%|&)\n(?!\\$)\n(\\.|\\*|:|!|\\^|~|=|\\?)?  # Twigils\n([\\pL\\pM_])             # Must start with Alpha or underscore\n(\n   [\\p{Digit}\\pL\\pM_]  # have alphanum/underscore, or a ' or -\n|                           # followed by an Alpha or underscore\n   [\\-'] [\\pL\\pM_]\n)*\n( \\[ .* \\] )?             # postcircumfix [ ]\n## methods\n(?:\n  (?:\n    ( \\. )\n    (\n       [\\pL\\pM]\n        (?:\n          [\\p{Digit}\\pL\\pM_]  # have alphanum/underscore, or a ' or -\n        |                          # followed by an Alpha or underscore\n          [\\-'] [\\pL\\pM_]\n        )*\n\n    )\n  )?\n  ( \\( .*?  \\) )\n)?",
           "name": "variable.other.identifier.interpolated.raku"
         },
         {
@@ -2779,7 +2779,7 @@
               "name": "variable.other.identifier.raku"
             }
           },
-          "match": "(?x)\n(\\$|@|%|&)\n(\\.|\\*|:|!|\\^|~|=|\\?)?\n(\n    (?:[\\p{Alpha}_])           # Must start with Alpha or underscore\n    (?:\n       [\\p{Digit}\\p{Alpha}_]  # have alphanum/underscore, or a ' or -\n    |                           # followed by an Alpha or underscore\n       [\\-'] [\\p{Alpha}_]\n    )*\n)",
+          "match": "(?x)\n(\\$|@|%|&)\n(\\.|\\*|:|!|\\^|~|=|\\?)?\n(\n    (?:[\\pL\\pM_])           # Must start with Alpha or underscore\n    (?:\n       [\\\\p{Digit}\\pL\\pM_]  # have alphanum/underscore, or a ' or -\n    |                           # followed by an Alpha or underscore\n       [\\-'] [\\pL\\pM_]\n    )*\n)",
           "name": "meta.variable.container.raku"
         }
       ]

--- a/grammars/raku.tmLanguage.json
+++ b/grammars/raku.tmLanguage.json
@@ -2779,7 +2779,7 @@
               "name": "variable.other.identifier.raku"
             }
           },
-          "match": "(?x)\n(\\$|@|%|&)\n(\\.|\\*|:|!|\\^|~|=|\\?)?\n(\n    (?:[\\pL\\pM_])           # Must start with Alpha or underscore\n    (?:\n       [\\\\p{Digit}\\pL\\pM_]  # have alphanum/underscore, or a ' or -\n    |                           # followed by an Alpha or underscore\n       [\\-'] [\\pL\\pM_]\n    )*\n)",
+          "match": "(?x)\n(\\$|@|%|&)\n(\\.|\\*|:|!|\\^|~|=|\\?)?\n(\n    (?:[\\pL\\pM_])           # Must start with Alpha or underscore\n    (?:\n       [\\p{Digit}\\pL\\pM_]  # have alphanum/underscore, or a ' or -\n    |                           # followed by an Alpha or underscore\n       [\\-'] [\\pL\\pM_]\n    )*\n)",
           "name": "meta.variable.container.raku"
         }
       ]


### PR DESCRIPTION
I modified the Raku sources (also did some unquoting the escape the... escape hell), then generated the grammars using generate-grammars.raku (get used to it, folks).

The changes in the JSON file should be the same as for https://github.com/Raku/atom-language/pull/102.